### PR TITLE
PR to setup Expiry for the Access Tokens.

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -5,6 +5,7 @@ class AuthenticationController < ApplicationController
   # we can't authenticate users with token for signup and login
   skip_before_action :authenticate_request, only: %i[register login]
 
+  # POST /register
   def register
     user = User.new(user_params)
     if user.save
@@ -16,6 +17,7 @@ class AuthenticationController < ApplicationController
     handle_token_creation_error(user, e)
   end
 
+  # POST /login
   def login
     user = User.find_by(email: params[:email])
     if user&.authenticate(params[:password])

--- a/app/controllers/budget_items_controller.rb
+++ b/app/controllers/budget_items_controller.rb
@@ -4,6 +4,7 @@
 class BudgetItemsController < ApplicationController
   before_action :set_budget, only: %i[create update destroy]
 
+  # POST /budgets/:id/budget_items
   def create
     budget_item = @budget.budget_items.build(budget_item_params)
     if budget_item.save
@@ -13,6 +14,7 @@ class BudgetItemsController < ApplicationController
     end
   end
 
+  # PUT /budgets/:id/budget_items/:id
   def update
     budget_item = @budget.budget_items.find(params[:id])
     if budget_item.update(budget_item_params)
@@ -22,6 +24,7 @@ class BudgetItemsController < ApplicationController
     end
   end
 
+  # DELETE /budgets/:id/budget_items/:id
   def destroy
     budget_item = @budget.budget_items.find(params[:id])
     if budget_item

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,7 +7,7 @@ class UsersController < ApplicationController
   # BUT we don't need it since we added it to ApplicationController to apply always except when
   # we tell it to 'skip_before_action'
 
-  # yes return all user info, even password digest (for now..)
+  # yes return all user info
   def show
     render json: @current_user.as_json(only: %i[id name email]), status: :ok
   end

--- a/config/initializers/jwt.rb
+++ b/config/initializers/jwt.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# JWT Config
+module JWTConfig
+  module_function
+
+  ACCESS_TOKEN_EXPIRY = 30.minutes
+  def access_token_expiry
+    ACCESS_TOKEN_EXPIRY
+  end
+end


### PR DESCRIPTION
This commit sets a 30 minute expiry to the JWT access token used for API calls while user is logged in the application. We have created a JWTConfig file in config/initializers which makes sure it is included whenever our server is run first so we always have access to it.