### PR TITLE
Create Refresh Tokens on login/Register and /refresh endpoint

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -3,13 +3,15 @@
 # Authentication Controller
 class AuthenticationController < ApplicationController
   # we can't authenticate users with token for signup and login
-  skip_before_action :authenticate_request, only: %i[register login]
+  skip_before_action :authenticate_request, only: %i[register login refresh]
 
   # POST /register
   def register
     user = User.new(user_params)
     if user.save
-      render json: { user:, token: generate_token(user) }, status: :created
+      token = generate_token(user)
+      refresh_token = generate_refresh_token(user)
+      render json: { user:, token:, refresh_token: refresh_token.token }, status: :created
     else
       render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
     end
@@ -21,10 +23,26 @@ class AuthenticationController < ApplicationController
   def login
     user = User.find_by(email: params[:email])
     if user&.authenticate(params[:password])
-      token = encode_token({ user_id: user.id })
-      render json: { user:, token: }, status: :ok
+      token = generate_token(user)
+      refresh_token = generate_refresh_token(user)
+      render json: { user:, token:, refresh_token: refresh_token.token }, status: :ok
     else
       render json: { errors: 'Invalid email or password' }, status: :unauthorized
+    end
+  end
+
+  # POST /refresh
+  def refresh
+    refresh_token = RefreshToken.find_by(token: params[:refresh_token])
+    if refresh_token&.expired?
+      render json: { errors: 'Refresh token has been expired' }, status: :unauthorized
+    else
+      user = refresh_token.user
+      token = generate_token(user) # access token
+      # invalidate the refresh token before we generate a new one
+      refresh_token.update!(expires_at: Time.zone.now)
+      new_refresh_token = generate_refresh_token(user)
+      render json: { token:, refresh_token: new_refresh_token.token }
     end
   end
 
@@ -43,5 +61,13 @@ class AuthenticationController < ApplicationController
     # destroy it
     user.destroy
     render json: { errors: "Failed to create token:#{error.message}" }, status: :unprocessable_entity
+  end
+
+  def generate_refresh_token(user)
+    RefreshToken.create!(
+      user:,
+      token: SecureRandom.hex(64),
+      expires_at: JWTConfig.refresh_access_token.from_now
+    )
   end
 end

--- a/app/models/refresh_token.rb
+++ b/app/models/refresh_token.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Refresh Tokens
+class RefreshToken < ApplicationRecord
+  belongs_to :user
+
+  validates :token, presence: true, uniqueness: true
+  validates :expires_at, presence: true
+
+  def expired?
+    Time.zone.now > expires_at
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,7 +36,7 @@ module PayoffpalApi
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = 'Central Time (US & Canada)'
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Only loads a smaller set of middleware suitable for API only apps.

--- a/config/initializers/jwt.rb
+++ b/config/initializers/jwt.rb
@@ -5,7 +5,13 @@ module JWTConfig
   module_function
 
   ACCESS_TOKEN_EXPIRY = 30.minutes
+  REFRESH_TOKEN_EXPIRY = 7.days
+
   def access_token_expiry
     ACCESS_TOKEN_EXPIRY
+  end
+
+  def refresh_access_token
+    REFRESH_TOKEN_EXPIRY
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   # trigger 'register' & 'signup' actions from AuthenticationController
   post '/register', to: 'authentication#register'
   post '/login', to: 'authentication#login'
+  post '/refresh', to: 'authentication#refresh'
   # trigger 'show' action from UsersController
   get '/profile', to: 'users#show'
 

--- a/db/migrate/20240909031707_create_refresh_tokens.rb
+++ b/db/migrate/20240909031707_create_refresh_tokens.rb
@@ -1,0 +1,11 @@
+class CreateRefreshTokens < ActiveRecord::Migration[7.1]
+  def change
+    create_table :refresh_tokens do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :token, null: false
+      t.datetime :expires_at, null: false
+      t.timestamps
+    end
+    add_index :refresh_tokens, :token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,39 +10,50 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_240_906_011_811) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_09_031707) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'budget_items', force: :cascade do |t|
-    t.bigint 'budget_id', null: false
-    t.string 'name'
-    t.decimal 'amount'
-    t.string 'category'
-    t.string 'item_type'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['budget_id'], name: 'index_budget_items_on_budget_id'
+  create_table "budget_items", force: :cascade do |t|
+    t.bigint "budget_id", null: false
+    t.string "name"
+    t.decimal "amount"
+    t.string "category"
+    t.string "item_type"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["budget_id"], name: "index_budget_items_on_budget_id"
   end
 
-  create_table 'budgets', force: :cascade do |t|
-    t.bigint 'user_id', null: false
-    t.date 'start_date'
-    t.date 'end_date'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['user_id'], name: 'index_budgets_on_user_id'
+  create_table "budgets", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.date "start_date"
+    t.date "end_date"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_budgets_on_user_id"
   end
 
-  create_table 'users', force: :cascade do |t|
-    t.string 'name', null: false
-    t.string 'email', null: false
-    t.string 'password_digest', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['email'], name: 'index_users_on_email', unique: true
+  create_table "refresh_tokens", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "token", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["token"], name: "index_refresh_tokens_on_token", unique: true
+    t.index ["user_id"], name: "index_refresh_tokens_on_user_id"
   end
 
-  add_foreign_key 'budget_items', 'budgets'
-  add_foreign_key 'budgets', 'users'
+  create_table "users", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "password_digest", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
+
+  add_foreign_key "budget_items", "budgets"
+  add_foreign_key "budgets", "users"
+  add_foreign_key "refresh_tokens", "users"
 end

--- a/spec/factories/refresh_tokens.rb
+++ b/spec/factories/refresh_tokens.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# FactoryBot.define do
+#   factory :refresh_token do
+#   end
+# end

--- a/spec/models/refresh_token_spec.rb
+++ b/spec/models/refresh_token_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RefreshToken, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This commit introduces refreshTokens, which can be used to refresh the access token. We have created a database to store the refresh tokens, their expiry dates. We invalidate a refresh token when /refresh is called by setting current time for its expiry before generating a new one. Fixes #10